### PR TITLE
Switch CI runners to gitlab.bsc.es

### DIFF
--- a/m/hut/blackbox.yml
+++ b/m/hut/blackbox.yml
@@ -3,6 +3,7 @@ modules:
     prober: http
     timeout: 5s
     http:
+      follow_redirects: true
       valid_status_codes: []  # Defaults to 2xx
       method: GET
   http_with_proxy:

--- a/m/hut/blackbox.yml
+++ b/m/hut/blackbox.yml
@@ -1,0 +1,160 @@
+modules:
+  http_2xx:
+    prober: http
+    timeout: 5s
+    http:
+      valid_status_codes: []  # Defaults to 2xx
+      method: GET
+  http_with_proxy:
+    prober: http
+    http:
+      proxy_url: "http://127.0.0.1:3128"
+      skip_resolve_phase_with_proxy: true
+  http_with_proxy_and_headers:
+    prober: http
+    http:
+      proxy_url: "http://127.0.0.1:3128"
+      proxy_connect_header:
+        Proxy-Authorization:
+          - Bearer token
+  http_post_2xx:
+    prober: http
+    timeout: 5s
+    http:
+      method: POST
+      headers:
+        Content-Type: application/json
+      body: '{}'
+  http_post_body_file:
+    prober: http
+    timeout: 5s
+    http:
+      method: POST
+      body_file: "/files/body.txt"
+  http_basic_auth_example:
+    prober: http
+    timeout: 5s
+    http:
+      method: POST
+      headers:
+        Host: "login.example.com"
+      basic_auth:
+        username: "username"
+        password: "mysecret"
+  http_2xx_oauth_client_credentials:
+    prober: http
+    timeout: 5s
+    http:
+      valid_http_versions: ["HTTP/1.1", "HTTP/2"]
+      follow_redirects: true
+      preferred_ip_protocol: "ip4"
+      valid_status_codes:
+        - 200
+        - 201
+      oauth2:
+        client_id: "client_id"
+        client_secret: "client_secret"
+        token_url: "https://api.example.com/token"
+        endpoint_params:
+          grant_type: "client_credentials"
+  http_custom_ca_example:
+    prober: http
+    http:
+      method: GET
+      tls_config:
+        ca_file: "/certs/my_cert.crt"
+  http_gzip:
+    prober: http
+    http:
+      method: GET
+      compression: gzip
+  http_gzip_with_accept_encoding:
+    prober: http
+    http:
+      method: GET
+      compression: gzip
+      headers:
+        Accept-Encoding: gzip
+  tls_connect:
+    prober: tcp
+    timeout: 5s
+    tcp:
+      tls: true
+  tcp_connect_example:
+    prober: tcp
+    timeout: 5s
+  imap_starttls:
+    prober: tcp
+    timeout: 5s
+    tcp:
+      query_response:
+        - expect: "OK.*STARTTLS"
+        - send: ". STARTTLS"
+        - expect: "OK"
+        - starttls: true
+        - send: ". capability"
+        - expect: "CAPABILITY IMAP4rev1"
+  smtp_starttls:
+    prober: tcp
+    timeout: 5s
+    tcp:
+      query_response:
+        - expect: "^220 ([^ ]+) ESMTP (.+)$"
+        - send: "EHLO prober\r"
+        - expect: "^250-STARTTLS"
+        - send: "STARTTLS\r"
+        - expect: "^220"
+        - starttls: true
+        - send: "EHLO prober\r"
+        - expect: "^250-AUTH"
+        - send: "QUIT\r"
+  irc_banner_example:
+    prober: tcp
+    timeout: 5s
+    tcp:
+      query_response:
+        - send: "NICK prober"
+        - send: "USER prober prober prober :prober"
+        - expect: "PING :([^ ]+)"
+          send: "PONG ${1}"
+        - expect: "^:[^ ]+ 001"
+  icmp_example:
+    prober: icmp
+    timeout: 5s
+    icmp:
+      preferred_ip_protocol: "ip4"
+      source_ip_address: "127.0.0.1"
+  dns_udp_example:
+    prober: dns
+    timeout: 5s
+    dns:
+      query_name: "www.prometheus.io"
+      query_type: "A"
+      valid_rcodes:
+        - NOERROR
+      validate_answer_rrs:
+        fail_if_matches_regexp:
+          - ".*127.0.0.1"
+        fail_if_all_match_regexp:
+          - ".*127.0.0.1"
+        fail_if_not_matches_regexp:
+          - "www.prometheus.io.\t300\tIN\tA\t127.0.0.1"
+        fail_if_none_matches_regexp:
+          - "127.0.0.1"
+      validate_authority_rrs:
+        fail_if_matches_regexp:
+          - ".*127.0.0.1"
+      validate_additional_rrs:
+        fail_if_matches_regexp:
+          - ".*127.0.0.1"
+  dns_soa:
+    prober: dns
+    dns:
+      query_name: "prometheus.io"
+      query_type: "SOA"
+  dns_tcp_example:
+    prober: dns
+    dns:
+      transport_protocol: "tcp" # defaults to "udp"
+      preferred_ip_protocol: "ip4" # defaults to "ip6"
+      query_name: "www.prometheus.io"

--- a/m/hut/gitlab-runner.nix
+++ b/m/hut/gitlab-runner.nix
@@ -21,6 +21,19 @@
           SHELL = "${pkgs.bash}/bin/bash";
         };
       };
+      gitlab-bsc-es-docker = {
+        registrationConfigFile = config.age.secrets.gitlabToken.path;
+        dockerImage = "debian:stable";
+        tagList = [ "docker" "xeon" ];
+        registrationFlags = [
+          "--locked='false'"
+          "--docker-network-mode host"
+        ];
+        environmentVariables = {
+          https_proxy = "http://localhost:23080";
+          http_proxy = "http://localhost:23080";
+        };
+      };
     };
   };
 

--- a/m/hut/gitlab-runner.nix
+++ b/m/hut/gitlab-runner.nix
@@ -9,18 +9,6 @@
     enable = true;
     settings.concurrent = 5;
     services = {
-      ovni-shell = {
-        registrationConfigFile = config.age.secrets.ovniToken.path;
-        executor = "shell";
-        tagList = [ "nix" "xeon" ];
-        registrationFlags = [
-          # Using space doesn't work, and causes it to misread the next flag
-          "--locked='false'"
-        ];
-        environmentVariables = {
-          SHELL = "${pkgs.bash}/bin/bash";
-        };
-      };
       gitlab-bsc-es-shell = {
         registrationConfigFile = config.age.secrets.gitlabToken.path;
         executor = "shell";
@@ -31,32 +19,6 @@
         ];
         environmentVariables = {
           SHELL = "${pkgs.bash}/bin/bash";
-        };
-      };
-      ovni-docker = {
-        registrationConfigFile = config.age.secrets.ovniToken.path;
-        dockerImage = "debian:stable";
-        tagList = [ "docker" "xeon" ];
-        registrationFlags = [
-          "--locked='false'"
-          "--docker-network-mode host"
-        ];
-        environmentVariables = {
-          https_proxy = "http://localhost:23080";
-          http_proxy = "http://localhost:23080";
-        };
-      };
-      nosv-docker = {
-        registrationConfigFile = config.age.secrets.nosvToken.path;
-        dockerImage = "debian:stable";
-        tagList = [ "docker" "xeon" ];
-        registrationFlags = [
-          "--docker-network-mode host"
-          "--docker-cpus 56"
-        ];
-        environmentVariables = {
-          https_proxy = "http://localhost:23080";
-          http_proxy = "http://localhost:23080";
         };
       };
     };

--- a/m/hut/gitlab-runner.nix
+++ b/m/hut/gitlab-runner.nix
@@ -2,6 +2,7 @@
 
 {
   age.secrets.ovniToken.file = ../../secrets/ovni-token.age;
+  age.secrets.gitlabToken.file = ../../secrets/gitlab-bsc-es-token.age;
   age.secrets.nosvToken.file = ../../secrets/nosv-token.age;
 
   services.gitlab-runner = {
@@ -10,6 +11,18 @@
     services = {
       ovni-shell = {
         registrationConfigFile = config.age.secrets.ovniToken.path;
+        executor = "shell";
+        tagList = [ "nix" "xeon" ];
+        registrationFlags = [
+          # Using space doesn't work, and causes it to misread the next flag
+          "--locked='false'"
+        ];
+        environmentVariables = {
+          SHELL = "${pkgs.bash}/bin/bash";
+        };
+      };
+      gitlab-bsc-es-shell = {
+        registrationConfigFile = config.age.secrets.gitlabToken.path;
         executor = "shell";
         tagList = [ "nix" "xeon" ];
         registrationFlags = [

--- a/m/hut/monitoring.nix
+++ b/m/hut/monitoring.nix
@@ -104,6 +104,7 @@
           targets = [
             "https://pm.bsc.es/"
             "https://jungle.bsc.es/"
+            "https://gitlab.bsc.es/"
           ];
         }];
         relabel_configs = [

--- a/secrets/gitlab-bsc-es-token.age
+++ b/secrets/gitlab-bsc-es-token.age
@@ -1,0 +1,11 @@
+age-encryption.org/v1
+-> ssh-ed25519 HY2yRg caTbx0NBmsTSmZH4HtBaxhsauWqWUDTesJqT08UsoEQ
+8ND31xuco+H8d5SKg8xsCFRPVDhU4d8UKwV1BnmKVjQ
+-> ssh-ed25519 CAWG4Q 4ETYuhCwHHECkut4DWDknMMgpAvFqtzLWVC2Wi2L8FM
+BGMvRnAfd8qZG5hzLefmk32FkGvwzE9pqBUyx4JY0co
+-> ssh-ed25519 MSF3dg hj5QL4ZfylN8/W/MXQHvVqtI7mRvlQOYr8HsaQEmPB0
+kvB7sljmmkswSGZDQnrwdTbTsN78EAwH3pz1pPe0Hu0
+-> )Q-grease vHF} [8p1> @7z;C"/
+tgSUKFyyrf2jLXZp+pakigwB2fRO/WFj2Qnt1aPjtVPEK92JbJ4
+--- xzM0AhV4gTQE0Q7inJNo9vFj+crJQxWeI7u9pl7bqAI
+α6nGJΦ0B’7F° –bίΩ½2®L³δΗ]²2zlΐ&e†KΔx®ΰι9SWNΰV"Mf€λΩKHUC:1b;9St‰λυ±DuΡ§η‹ΟΆΜ΅θΠιξΐ–ΤfΥ7¨ξ1§I(υdΣώτ‡οσ

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -6,6 +6,7 @@ let
   safe = keys.hostGroup.safe ++ adminsKeys;
 in
 {
+  "gitlab-bsc-es-token.age".publicKeys = hut;
   "ovni-token.age".publicKeys = hut;
   "nosv-token.age".publicKeys = hut;
   "nix-serve.age".publicKeys = hut;


### PR DESCRIPTION
With the crash of the PM VM we temporarily move the CI runners to operate on gitlab.bsc.es. This PR also monitors the state of the PM website so we are informed if it comes back.